### PR TITLE
Added new teamleagues/id/info GET endpoint.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>
+
+		<!-- OpenAPI / Swagger UI (springdoc 1.x for Spring Boot 2.x) -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.7.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/softballreference/softballreferenceapi/config/OpenApiConfig.java
+++ b/src/main/java/com/softballreference/softballreferenceapi/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.softballreference.softballreferenceapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI softballReferenceOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Softball Reference API")
+                        .description("Softball statistics REST API backed by a relational database.")
+                        .version("v1"))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_SCHEME_NAME, new SecurityScheme()
+                                .name(BEARER_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/softballreference/softballreferenceapi/controllers/TeamLeagueController.java
+++ b/src/main/java/com/softballreference/softballreferenceapi/controllers/TeamLeagueController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.softballreference.softballreferenceapi.exception.RecordNotFoundException;
 import com.softballreference.softballreferenceapi.model.dao.GameDao;
 import com.softballreference.softballreferenceapi.model.dao.TeamLeagueDao;
+import com.softballreference.softballreferenceapi.model.dao.TeamLeaguePlayerDao;
 import com.softballreference.softballreferenceapi.model.entity.TeamLeague;
 import com.softballreference.softballreferenceapi.model.entity.response_dto.GameSummaryResponse;
 import com.softballreference.softballreferenceapi.model.entity.response_dto.PlayerBindResponse;
@@ -56,7 +57,7 @@ public class TeamLeagueController {
      * in Id.
      * 
      * The @GetMapping annotation ties this method to the /teamleagues/{id} URI from
-     * aGET http request, while the @PathVariable annotation binds the template
+     * a GET http request, while the @PathVariable annotation binds the template
      * variable from therequest URI mapping to the method parameter. If they have
      * the same name then you don't need to qualify the annotation with the string
      * name.
@@ -71,13 +72,38 @@ public class TeamLeagueController {
      *                                 not need to declare it as "throwable".
      */
     @GetMapping("/{id}")
-    public ResponseEntity<SummaryStatLineResponse> getTeamLeagueById(@PathVariable("id") Long teamLeagueId) {
+    public ResponseEntity<SummaryStatLineResponse> getSummaryStatLineByTeamLeagueId(
+            @PathVariable("id") Long teamLeagueId) {
         SummaryStatLineResponse response = restService.getSummaryStatLineResponseByTeamLeagueId(teamLeagueId);
 
         if (response == null)
             throw new RecordNotFoundException("No teamleague exists for given id", teamLeagueId);
 
         return new ResponseEntity<SummaryStatLineResponse>(response, new HttpHeaders(), HttpStatus.OK);
+    }
+
+    /**
+    * Returns the {@link TeamLeagueBindResponse} from the {@link TeamLeagueDao}
+    * that matches the passed in Id.
+    *
+    * @param teamLeagueId
+    * @return the {@link TeamLeagueBindResponse} associated with the
+    *         {@code Long} Id as part of an HttpStatus.OK response.
+    * @throws RecordNotFoundException The exception is thrown if now
+    *                                 {@link TeamLeague} is associated with the
+    *                                 Id. NOTE: This exception is of type
+    *                                 {@link RuntimeException} so this method
+    *                                 does not need to declare it as
+    *                                 "throwable".
+    */
+    @GetMapping("/{id}/info")
+    public ResponseEntity<TeamLeagueBindResponse> getTeamLeagueByTeamLeagueId(@PathVariable("id") Long teamLeagueId) {
+        TeamLeagueBindResponse response = restService.getTeamLeagueByTeamLeagueId(teamLeagueId);
+
+        if (response == null)
+            throw new RecordNotFoundException("No teamleague exists for given id", teamLeagueId);
+
+        return new ResponseEntity<TeamLeagueBindResponse>(response, new HttpHeaders(), HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/com/softballreference/softballreferenceapi/service/RestService.java
+++ b/src/main/java/com/softballreference/softballreferenceapi/service/RestService.java
@@ -74,7 +74,7 @@ public class RestService {
 	StatLineDao statLineDao;
 
 	/*
-	 * One-off dropdown populaters
+	 * One-off dropdown populaters and utility calls
 	 */
 
 	/**
@@ -128,6 +128,25 @@ public class RestService {
 	 */
 	public boolean doesTeamLeagueExistById(Long teamLeagueId) {
 		return teamLeagueDao.existsById(teamLeagueId);
+	}
+
+	/**
+	 * Fetches the single {@link TeamLeague} object associated with the passed in
+	 * {@code teamLeagueId} and wrapped in a {@link TeamLeagueBindResponse}.
+	 * 
+	 * @param teamLeagueId the {@code Long} Id associated with the
+	 *                     {@link TeamLeague} to fetch.
+	 * @return a {@link TeamLeagueBindResponse} object built from the
+	 *         {@link TeamLeague} entity associated with the {@code teamLeagueId},
+	 *         or {@code null} if one doesn't exist in the db.
+	 */
+	public TeamLeagueBindResponse getTeamLeagueByTeamLeagueId(Long teamLeagueId) {
+		Optional<TeamLeague> teamLeagueOptional = teamLeagueDao.findById(teamLeagueId);
+
+		if (teamLeagueOptional.isPresent())
+			return ResponseAndEntityBuilder.buildTeamLeagueBindResponse(teamLeagueOptional.get());
+		else
+			return null;
 	}
 
 	/**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,9 @@ admin.username=${ADMIN_USERNAME:}
 admin.password-hash=${ADMIN_PASSWORD_HASH:}
 jwt.secret=${JWT_SECRET:}
 jwt.expiration-ms=86400000
+
+# Swagger UI / OpenAPI (springdoc)
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.api-docs.path=/v3/api-docs


### PR DESCRIPTION
Closes https://github.com/bradykey/softball-reference-api/issues/12

Consisted of a new RestService.getTeamLeagueByTeamLeagueId() method that creates a single TeamLeagueBindResponse from a fetched TeamLeague as well as a controller endpoint that calls and returns the response.

Also turned on Swagger @ /swagger-ui.html:
* Added springdoc-openapi-ui 1.7.0 to pom.xml (the 1.x line for Spring Boot 2.x)
* Added swagger/openapi paths to application.properties
* Added OpenApiConfig.java with API metadata and a bearerAuth JWT scheme so you can click Authorize in the UI and paste a token for the protected POST endpoints